### PR TITLE
Update selfContact status to reflect connection state

### DIFF
--- a/connection.hpp
+++ b/connection.hpp
@@ -83,6 +83,7 @@ private:
     uint addContacts(const QStringList &identifiers);
 
     void updateContactsState(const QStringList &identifiers);
+    void updateSelfContactState(Tp::ConnectionStatus status);
     void setSubscriptionState(const QStringList &identifiers, const QList<uint> &handles, uint state);
 
     void startMechanismWithData(const QString &mechanism, const QByteArray &data, Tp::DBusError *error);

--- a/connection.hpp
+++ b/connection.hpp
@@ -34,8 +34,7 @@ public:
     void doConnect(Tp::DBusError *error);
 
     QStringList inspectHandles(uint handleType, const Tp::UIntList &handles, Tp::DBusError *error);
-    Tp::BaseChannelPtr createChannel(const QString &channelType, uint targetHandleType,
-                                         uint targetHandle, const QVariantMap &request, Tp::DBusError *error);
+    Tp::BaseChannelPtr createChannel(const QVariantMap &request, Tp::DBusError *error);
 
     Tp::UIntList requestHandles(uint handleType, const QStringList &identifiers, Tp::DBusError *error);
 


### PR DESCRIPTION
When the simple presence interface is available, clients use this to
more accurately deterine connected state. This will be used for
displaying and determinining if we're actually online.
