### PR TITLE
setSubscribtionState

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -1125,7 +1125,7 @@ void MorseConnection::whenContactListChanged()
 //    Tp::HandleIdentifierMap identifiers;
 //    Tp::HandleIdentifierMap removals;
 
-    QVector<uint> handles;
+    QList<uint> handles;
     QVector<MorseIdentifier> identifiers;
     handles.reserve(ids.count());
     identifiers.reserve(ids.count());
@@ -1135,7 +1135,7 @@ void MorseConnection::whenContactListChanged()
         handles.append(ensureContact(identifiers.last()));
     }
 
-    setSubscriptionState(handles, Tp::SubscriptionStateYes);
+    setSubscriptionState(identifiers, handles, Tp::SubscriptionStateYes);
     updateContactsStatus(identifiers);
 
     contactListIface->setContactListState(Tp::ContactListStateSuccess);


### PR DESCRIPTION
```
$ LANG=C make
[ 20%] Automatic moc for target telepathy-morse
[ 20%] Built target telepathy-morse_automoc
Scanning dependencies of target telepathy-morse
[ 20%] Building CXX object CMakeFiles/telepathy-morse.dir/connection.cpp.o
/home/christoph/build/telepathy-morse/connection.cpp: In member function 'void MorseConnection::whenContactListChanged()':
/home/christoph/build/telepathy-morse/connection.cpp:1138:59: error: no matching function for call to 'MorseConnection::setSubscriptionState(QVector<unsigned int>&, Tp::SubscriptionState)'
     setSubscriptionState(handles, Tp::SubscriptionStateYes);
                                                           ^
/home/christoph/build/telepathy-morse/connection.cpp:1044:6: note: candidate: void MorseConnection::setSubscriptionState(const QVector<MorseIdentifier>&, const QList<unsigned int>&, uint)
 void MorseConnection::setSubscriptionState(const QVector<MorseIdentifier> &identifiers, const QList<uint> &handles, uint state)
      ^~~~~~~~~~~~~~~
/home/christoph/build/telepathy-morse/connection.cpp:1044:6: note:   candidate expects 3 arguments, 2 provided
CMakeFiles/telepathy-morse.dir/build.make:86: recipe for target 'CMakeFiles/telepathy-morse.dir/connection.cpp.o' failed
make[2]: *** [CMakeFiles/telepathy-morse.dir/connection.cpp.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/telepathy-morse.dir/all' failed
make[1]: *** [CMakeFiles/telepathy-morse.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2

```

You removed the corresponding function w/ https://github.com/TelepathyQt/telepathy-morse/commit/72bc262ff77b34dfce8b9db25097499bea75a3dd
(Previously it did nothing? But there's that call to `updateContactsStatus` with that `identifiers` passed to `setSubscribtionState` directly below, so that did the job? ^^)
