### PR TITLE
Increase minimum required CMake version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 
 project(TelepathyMorse
     VERSION 0.2.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Features
 Requirements
 ============
 
-* CMake 3.2+
+* CMake 3.6+
 * Qt 5.6+
 * TelepathyQt 0.9.7+
 * TelegramQt 0.2.0+ (not released yet; please use `master` branch)


### PR DESCRIPTION
As current TelegramQt requires CMake 3.6 or newer, building current TelepathyMorse against it using a recent CMake (like 3.10) fails with `Unknown arguments specified` error for `"NOT" "Core" "IN_LIST" "_WANTED_COMPONENTS"` at `TelegramQt5Config.cmake:10`. CMake warns to set CMP0057, but doing this in TelepathyMorse does not help as the minimum required version 3.1 does not know the CMP0057 and TelegramQt requires a newer version. Increasing the minimum required CMake version for TelepathyMorse fixes the issue. (I think even increasing it to version 3.3, that introduced CMP0057, would fix it, but as TelegramQt requires version 3.6+ it might be better to be the same.)